### PR TITLE
chore: allow release scope for CI-generated messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -32,5 +32,6 @@ module.exports = {
         'test',
       ],
     ],
+    'scope-enum': [2, 'always', ['release']],
   },
 };


### PR DESCRIPTION
## Allow `release` Scope in Commit Messages

### Summary
This PR updates the `commitlint.config.js` file to allow the use of `release` as a valid scope in commit messages. This change is required to support CI-generated commits from tools like **semantic-release**, which use messages such as:

```
chore(release): 1.0.0-develop.1 [skip ci]
```

### Why
Without this update, these automatically generated commits fail commit linting, blocking the release process.

### Changes
- Added `"release"` to the allowed values for the `scope-enum` rule in `commitlint.config.js`

### Impact
- Ensures smoother CI workflows for releases
- Prevents false positives from commit lint validation during release automation