### PR TITLE
chore: update GKE setup for ARM compatibility

### DIFF
--- a/examples/gcp/cloud-sql/midaz.tfvars-example
+++ b/examples/gcp/cloud-sql/midaz.tfvars-example
@@ -1,12 +1,12 @@
 # Existing values
 project_id        = "<PUT-YOUR-PROJECT-ID>"
 instance_name     = "midaz-postgresql"
-region            = "us-east1"
-zone              = "us-east1-b"
+region            = "us-central1"
+zone              = "us-central1-a"
 instance_tier     = "db-custom-2-8192" # 2 vCPUs, 8GB RAM
 disk_size         = 50                 # GB
 high_availability = false              # Set to true for production
-backup_location   = "us-east1"
+backup_location   = "us-central1"
 vpc_self_link     = "projects/<PUT-YOUR-PROJECT-ID>/global/networks/midaz-network"
 
 # Database configuration

--- a/examples/gcp/gke/main.tf
+++ b/examples/gcp/gke/main.tf
@@ -38,9 +38,11 @@ module "gke" {
   release_channel   = var.release_channel # Required for Pod Security Standards
 
   // Node pools
+  remove_default_node_pool = true
+
   node_pools = [
     {
-      name               = "default-node-pool"
+      name               = "midaz-node-pool"
       machine_type       = var.machine_type
       min_count          = var.min_node_count
       max_count          = var.max_node_count

--- a/examples/gcp/gke/midaz.tfvars-example
+++ b/examples/gcp/gke/midaz.tfvars-example
@@ -1,7 +1,7 @@
 # Project and location
 project_id = "<PUT-YOUR-PROJECT-ID>"
-region     = "us-east1"
-zones      = ["us-east1-b", "us-east1-c", "us-east1-d"]
+region     = "us-central1"
+zones      = ["us-central1-a", "us-central1-b", "us-central1-f"]
 
 # Cluster configuration
 cluster_name        = "midaz-cluster"
@@ -17,10 +17,10 @@ master_ipv4_cidr_block  = "172.16.0.0/28"
 enable_private_endpoint = false
 
 # Node pool configuration
-machine_type       = "e2-standard-2"
-min_node_count     = 3
+machine_type       = "t2a-standard-2"
+min_node_count     = 1
 max_node_count     = 15
-initial_node_count = 3
+initial_node_count = 1
 disk_size_gb       = 100
 
 # Master authorized networks

--- a/examples/gcp/valkey/midaz.tfvars-example
+++ b/examples/gcp/valkey/midaz.tfvars-example
@@ -1,7 +1,7 @@
 # Project and instance configuration
 project_id    = "<PUT-YOUR-PROJECT-ID>"
 instance_name = "midaz-valkey"
-region        = "us-east1"
+region        = "us-central1"
 
 # Memory and replication settings
 replica_count  = 0
@@ -28,4 +28,4 @@ environment = "devops"
 # Zone and cluster configuration
 mode                          = "CLUSTER_DISABLED"
 zone_distribution_config_mode = "MULTI_ZONE"
-zone_distribution_config_zone = "us-east1-b"
+zone_distribution_config_zone = "us-central1-a"

--- a/examples/gcp/vpc/midaz.tfvars-example
+++ b/examples/gcp/vpc/midaz.tfvars-example
@@ -1,5 +1,5 @@
 project_id          = "<PUT-YOUR-PROJECT-ID>" # Your GCP project ID
-region              = "us-east1"      # A common GCP region
+region              = "us-central1"      # A common GCP region
 network_name        = "midaz-network" # Using the default value
 subnet_cidr         = "10.0.0.0/16"   # Using the default value
 pods_cidr_range     = "10.1.0.0/16"   # Using the default value


### PR DESCRIPTION
- Set default GCP zone to us-central for ARM-based GKE instances
- Removed default GKE node pool to avoid unmanaged resources
- Renamed node pool to 'midaz-node-pool' for consistency
- Change the nodepool min and initial node count to 1