### PR TITLE
feat: add AWS Load Balancer Controller support and improve EKS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,10 @@ For detailed configuration options and advanced setup, please refer to the [Mida
 
 When deploying on AWS, please note the following important requirements:
 
-- **Cluster Autoscaler** and **NGINX Ingress Controller** (if required by the client) **must be installed and managed manually or by GitOps or any pipeline that the client uses**.
-- It is **not possible to configure cluster atuscaler and NGINX ingrees by default** via the `addons` block in `main.tf`.
+- **Cluster Autoscaler**, **AWS Load Balancer Controller**, and **NGINX Ingress Controller** (if required by the client) **must be installed and managed manually or by GitOps or any pipeline that the client uses**.
+- It is **not possible to configure cluster autoscaler, AWS Load Balancer Controller, and NGINX ingress by default** via the `addons` block in `main.tf`.
 - These components require manual installation using their respective Helm charts after the EKS cluster is deployed.
+- **AWS Load Balancer Controller** is required if the client wants to expose Midaz APIs inside the VPC (internal ALB) or to the internet (public ALB - not recommended). The IAM role for the AWS Load Balancer Controller is automatically created in `eks/iam.tf` and should be used by the controller's service account. VPC subnets are already tagged with the required tags (`kubernetes.io/role/elb` for public subnets and `kubernetes.io/role/internal-elb` for private subnets) for automatic subnet discovery by the controller.
 - If the client is deploying **Midaz or plugins** using **Amazon MQ**, they **must set `RABBITMQ_URI: "amqps"`** in Helm values for any component that uses cloud AMQP.
 - If the client wants a **private EKS cluster**, they need to set these variables in their `midaz.tfvars` file: `cluster_endpoint_private_access = true`, `cluster_endpoint_public_access = false`, and there is **no need to set `allowed_api_access_cidrs`**.
 
@@ -307,6 +308,7 @@ When deploying on AWS, please note the following important requirements:
 For installation guidance, please refer to the official Helm charts:
 
 - [Cluster Autoscaler Helm Chart](https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler)
+- [AWS Load Balancer Controller Helm Chart](https://artifacthub.io/packages/helm/aws/aws-load-balancer-controller)
 - [NGINX Ingress Controller Helm Chart](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx)
 
 ## VPN and Private Kubernetes Access

--- a/examples/aws/eks/main.tf
+++ b/examples/aws/eks/main.tf
@@ -106,6 +106,14 @@ module "eks" {
       type        = "ingress"
       self        = true
     }
+    ingress_alb_health_check = {
+      description = "Allow ALB to access NodePort services for health checks"
+      protocol    = "tcp"
+      from_port   = 1025
+      to_port     = 65535
+      type        = "ingress"
+      cidr_blocks = [data.aws_vpc.selected.cidr_block]
+    }
     egress_vpc = {
       description = "Allow outbound traffic to VPC CIDR"
       protocol    = "-1"
@@ -146,7 +154,8 @@ module "eks" {
       }
 
       metadata_options = {
-        http_tokens = "required"
+        http_tokens                 = "required"
+        http_put_response_hop_limit = 2
       }
 
       tags = merge({

--- a/examples/aws/vpc/main.tf
+++ b/examples/aws/vpc/main.tf
@@ -25,18 +25,25 @@ module "vpc" {
   create_flow_log_cloudwatch_log_group = var.flow_logs_enabled
   create_flow_log_cloudwatch_iam_role  = var.flow_logs_enabled
 
-  private_subnet_tags = {
-    Type = "private"
-  }
+  private_subnet_tags = merge(
+    {
+      Type                              = "private"
+      "kubernetes.io/role/internal-elb" = "1"
+    },
+    var.cluster_name != "" ? { "kubernetes.io/cluster/${var.cluster_name}" = "owned" } : {}
+  )
 
-  public_subnet_tags = {
-    Type = "public"
-  }
+  public_subnet_tags = merge(
+    {
+      Type                     = "public"
+      "kubernetes.io/role/elb" = "1"
+    },
+    var.cluster_name != "" ? { "kubernetes.io/cluster/${var.cluster_name}" = "owned" } : {}
+  )
 
   database_subnet_tags = {
     Type = "database"
   }
-
   tags = merge({
     Environment = lower(var.environment)
     ManagedBy   = "Terraform"

--- a/examples/aws/vpc/midaz.tfvars-example
+++ b/examples/aws/vpc/midaz.tfvars-example
@@ -19,6 +19,9 @@ one_nat_gateway_per_az = false
 # Availability Zones
 availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
 
+# EKS Cluster Configuration
+cluster_name = "midaz-eks"
+
 # Additional Tags
 additional_tags = {
   "ManagedBy" = "terraform"

--- a/examples/aws/vpc/variables.tf
+++ b/examples/aws/vpc/variables.tf
@@ -63,6 +63,12 @@ variable "enable_dns_support" {
   default     = true
 }
 
+variable "cluster_name" {
+  description = "EKS cluster name for subnet tagging"
+  type        = string
+  default     = ""
+}
+
 variable "additional_tags" {
   description = "Tags additional for resources use."
   type        = map(string)


### PR DESCRIPTION
- Add kubernetes.io/role/elb and kubernetes.io/role/internal-elb tags to VPC subnets
- Add kubernetes.io/cluster/<cluster-name>=owned tag support via cluster_name variable
- Add ingress rule for ALB health checks to EKS node security group (ports 1025-65535)
- Set http_put_response_hop_limit=2 in EKS node metadata options for IRSA compatibility
- Update README with AWS Load Balancer Controller requirements and subnet tagging info
- Add cluster_name variable to VPC module for EKS integration