### PR TITLE
feat: update AWS instance types to newer generation and add disclaimer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ ehthumbs.db
 Thumbs.db
 node_modules
 package-lock.json
+
+# Plans and documentation (local only)
+docs/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ This repository provides Terraform examples for clients and open-source users to
 
 This repository provides Terraform examples for deploying foundation infrastructure. Please note that we do not provide a CI/CD pipeline implementation for these Terraform configurations. Users must implement their own CI/CD pipelines according to their specific needs and requirements.
 
+### Instance Types Disclaimer
+
+The instance types specified in the example `.tfvars` files are provided as starting points and examples only. Users are **fully responsible** for selecting appropriate instance types based on their specific workload requirements.
+
+**Key considerations:**
+
+- **Production Workloads:** The default instance types in examples may not be suitable for production environments. Always evaluate your expected transaction volume, concurrent connections, and data size before deploying.
+
+- **High TPS Requirements:** If your application requires high transactions per second (TPS), you must select appropriately sized instances. Consider CPU cores, memory, network bandwidth, and storage IOPS for your expected workload.
+
+- **Cost Optimization:** Larger instances provide more resources but at higher cost. Start with your expected workload profile and scale as needed.
+
+Before selecting instance types, review the official documentation for your chosen cloud provider (AWS, GCP, or Azure) regarding instance/machine type specifications and recommendations.
+
+**Disclaimer:** Lerian Studio is not responsible for performance issues, costs, or other impacts resulting from instance type selections.
+
 ## Project Structure
 
 ```

--- a/examples/aws/amazonmq/midaz.tfvars-example
+++ b/examples/aws/amazonmq/midaz.tfvars-example
@@ -6,7 +6,7 @@ environment = "<environment>" # Environment identifier
 deployment_mode     = "SINGLE_INSTANCE" # SINGLE_INSTANCE, ACTIVE_STANDBY_MULTI_AZ, or CLUSTER_MULTI_AZ
 engine_type         = "RabbitMQ"        # ActiveMQ or RabbitMQ
 engine_version      = "3.13"         # Broker engine version
-host_instance_type  = "mq.t3.micro"     # Broker instance type
+host_instance_type  = "mq.m7g.large"    # Broker instance type
 publicly_accessible = false             # Set to true to allow public access
 
 # Credentials (use a secrets management system in production)

--- a/examples/aws/documentdb-plugin-crm/crm.tfvars-example
+++ b/examples/aws/documentdb-plugin-crm/crm.tfvars-example
@@ -3,7 +3,7 @@ name        = "midaz-plugin-crm-docdb" # Name identifier for the DocumentDB clus
 environment = "<environment>"          # Environment identifier
 
 # Cluster Configuration
-instance_class  = "db.t3.medium" # Instance class for the DocumentDB instances
+instance_class  = "db.r8g.large" # Instance class for the DocumentDB instances
 instances_count = 2              # Number of instances in the cluster
 
 # Credentials (use a secrets management system in production)

--- a/examples/aws/documentdb-plugin-fee/fee.tfvars-example
+++ b/examples/aws/documentdb-plugin-fee/fee.tfvars-example
@@ -3,7 +3,7 @@ name        = "midaz-plugin-fee-docdb" # Name identifier for the DocumentDB clus
 environment = "<environment>"          # Environment identifier
 
 # Cluster Configuration
-instance_class  = "db.t3.medium" # Instance class for the DocumentDB instances
+instance_class  = "db.r8g.large" # Instance class for the DocumentDB instances
 instances_count = 2              # Number of instances in the cluster
 
 # Credentials (use a secrets management system in production)

--- a/examples/aws/documentdb/midaz.tfvars-example
+++ b/examples/aws/documentdb/midaz.tfvars-example
@@ -3,7 +3,7 @@ name        = "midaz-docdb"   # Name identifier for the DocumentDB cluster
 environment = "<environment>" # Environment identifier
 
 # Cluster Configuration
-instance_class  = "db.t3.medium" # Instance class for the DocumentDB instances
+instance_class  = "db.r8g.large" # Instance class for the DocumentDB instances
 instances_count = 2              # Number of instances in the cluster
 
 # Credentials (use a secrets management system in production)

--- a/examples/aws/rds/midaz.tfvars-example
+++ b/examples/aws/rds/midaz.tfvars-example
@@ -8,7 +8,7 @@ engine                = "postgres"
 engine_version        = "16.3"
 family                = "postgres16"
 major_engine_version  = "16"
-instance_class        = "db.t3.medium"
+instance_class        = "db.m7g.large"
 allocated_storage     = 20
 max_allocated_storage = 100
 database_name         = "midaz"
@@ -20,7 +20,7 @@ deletion_protection   = true
 parameters = [
   {
     name         = "max_connections"
-    value        = "100"
+    value        = "LEAST({DBInstanceClassMemory/9531392},5000)" # Auto-scales based on instance memory
     apply_method = "pending-reboot" # Required for static parameters
   },
   {


### PR DESCRIPTION
## Changes

- Update RDS primary instance type to `db.m7g.large`
- Update AmazonMQ instance type to `mq.m7g.large`
- Update DocumentDB instance types to `db.r8g.large` (main, plugin-crm, plugin-fee)
- Update RDS `max_connections` parameter to auto-scale based on instance memory: `LEAST({DBInstanceClassMemory/9531392},5000)`
- Add Instance Types Disclaimer section to README.md (under Important Note)
- Add `docs/` to .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Instance Types Disclaimer" section with guidance on selecting appropriate instance types for cloud deployments, including production workload considerations, TPS requirements, and cost optimization tips.

* **Configuration**
  * Updated example configurations with recommended instance type specifications and improved auto-scaling parameters based on instance memory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->