### PR TITLE
ci: migrate workflow jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     # Checkout repository code in PR
     - name: Checkout in PR
@@ -137,7 +137,7 @@ jobs:
 
   release:
     needs: validate  # Only run after validation succeeds
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'push'
     steps:
     # Create GitHub App token for better rate limits


### PR DESCRIPTION
The org is standardizing CI on Blacksmith runners, a drop-in replacement for GitHub-hosted runners that is roughly 2x faster at about half the per-minute price. This swaps the GitHub-hosted labels in this repo's workflows to the same `blacksmith-4vcpu-ubuntu-2404` label used across the rest of the org.

```yaml
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
```