### PR TITLE
chore(ci): migrate CI runners to Blacksmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     # Checkout repository code in PR
     - name: Checkout in PR
@@ -137,7 +137,7 @@ jobs:
 
   release:
     needs: validate  # Only run after validation succeeds
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'push'
     steps:
     # Create GitHub App token for better rate limits


### PR DESCRIPTION
Migrates this repository's GitHub Actions jobs from GitHub-hosted runners to Blacksmith runners, as part of the org-wide migration. Every hardcoded `ubuntu-*` label (both `runs-on:` and `runner_type:` inputs passed to shared workflows) now points to Blacksmith:

```yaml
runs-on: blacksmith-4vcpu-ubuntu-2404
```

Jobs pinned to `ubuntu-22.04` map to `blacksmith-4vcpu-ubuntu-2204` to keep the same OS version. Self-hosted labels (`eveo-*`, `self-hosted`) are untouched, and no other workflow logic changed.
